### PR TITLE
fix import syntax for python 2+3 compatibility

### DIFF
--- a/colorpy/blackbody.py
+++ b/colorpy/blackbody.py
@@ -67,13 +67,13 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import absolute_import
+
 import math
 import numpy
 import pylab
 
-import colormodels
-import ciexyz
-import plots
+from . import colormodels, ciexyz, plots
 
 # Physical constants in mks units
 PLANCK_CONSTANT   = 6.6237e-34      # J-sec

--- a/colorpy/ciexyz.py
+++ b/colorpy/ciexyz.py
@@ -116,9 +116,11 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import absolute_import
+
 import math, numpy
 
-import colormodels
+from . import colormodels
 
 # Assumed physical brightness of the monitor [W/m^2]
 #   80 cd/m^2 * 20.3 mW/cd (assuming light at 556 nm)

--- a/colorpy/figures.py
+++ b/colorpy/figures.py
@@ -42,13 +42,10 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
-import colormodels
-import illuminants
-import plots
-import blackbody
-import rayleigh
-import thinfilm
-import misc
+from __future__ import absolute_import
+
+from . import (colormodels, illuminants, plots, blackbody, rayleigh,
+               thinfilm, misc)
 
 def figures ():
     '''Create all the ColorPy sample figures.'''

--- a/colorpy/illuminants.py
+++ b/colorpy/illuminants.py
@@ -88,9 +88,9 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
-import ciexyz
-import blackbody
-import plots
+from __future__ import absolute_import
+
+from . import ciexyz, blackbody, plots
 
 # table of CIE Illuminant D65 spectrum.
 # data from: http://cvrl.ioo.ucl.ac.uk/database/data/cie/Illuminantd65.txt

--- a/colorpy/misc.py
+++ b/colorpy/misc.py
@@ -61,11 +61,11 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import absolute_import
+
 import math, numpy
 
-import colormodels
-import ciexyz
-import plots
+from . import colormodels, ciexyz, plots
 
 # Some sample lists of displayable RGB colors as hex strings
 

--- a/colorpy/plots.py
+++ b/colorpy/plots.py
@@ -121,13 +121,12 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import math
 import numpy, pylab
 
-import colormodels
-import ciexyz
+from . import colormodels, ciexyz
 
 # Miscellaneous utilities for plots
 

--- a/colorpy/rayleigh.py
+++ b/colorpy/rayleigh.py
@@ -62,14 +62,12 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import absolute_import
+
 import math
 import numpy, pylab
 
-import colormodels
-import ciexyz
-import illuminants
-import blackbody
-import plots
+from . import colormodels, ciexyz, illuminants, blackbody, plots
 
 def rayleigh_scattering (wl_nm):
     '''Get the Rayleigh scattering factor for the wavelength.

--- a/colorpy/test.py
+++ b/colorpy/test.py
@@ -27,16 +27,12 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import unittest
 
-import test_colormodels
-import test_ciexyz
-import test_illuminants
-import test_blackbody
-import test_rayleigh
-import test_thinfilm
+from . import (test_colormodels, test_ciexyz, test_illuminants,
+               test_blackbody, test_rayleigh, test_thinfilm)
 
 def test ():
     # no test cases for plots/misc - but figures.py will exercise those.

--- a/colorpy/test_blackbody.py
+++ b/colorpy/test_blackbody.py
@@ -22,14 +22,13 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import math
 import numpy
 import unittest
 
-import blackbody
-import colormodels
+from . import blackbody, colormodels
 
 # FIXME: The following calculation is not working currently.
 # It is an attempt to get the scale of the intensity correct.

--- a/colorpy/test_ciexyz.py
+++ b/colorpy/test_ciexyz.py
@@ -22,12 +22,12 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import random
 import unittest
 
-import ciexyz
+from . import ciexyz
 
 
 class TestCiexyz(unittest.TestCase):

--- a/colorpy/test_colormodels.py
+++ b/colorpy/test_colormodels.py
@@ -22,13 +22,12 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import math, random, numpy
 import unittest
 
-import colormodels
-import ciexyz
+from . import colormodels, ciexyz
 
 # Functions to calculate the cutoff point between various algorithms.
 # These do not really belong here...

--- a/colorpy/test_illuminants.py
+++ b/colorpy/test_illuminants.py
@@ -22,11 +22,11 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import unittest
 
-import illuminants
+from . import illuminants
 
 
 class TestIlluminants(unittest.TestCase):

--- a/colorpy/test_rayleigh.py
+++ b/colorpy/test_rayleigh.py
@@ -22,16 +22,14 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import math
 import numpy
 import random
 import unittest
 
-import ciexyz
-import rayleigh
-import illuminants
+from . import ciexyz, rayleigh, illuminants
 
 
 class TestRayleigh(unittest.TestCase):

--- a/colorpy/test_thinfilm.py
+++ b/colorpy/test_thinfilm.py
@@ -22,13 +22,12 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import random
 import unittest
 
-import illuminants
-import thinfilm
+from . import illuminants, thinfilm
 
 
 class TestThinFilm(unittest.TestCase):

--- a/colorpy/thinfilm.py
+++ b/colorpy/thinfilm.py
@@ -82,12 +82,11 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import absolute_import
+
 import math, cmath, numpy
 
-import colormodels
-import ciexyz
-import illuminants
-import plots
+from . import colormodels, ciexyz, illuminants, plots
 
 class thin_film:
     '''A thin film of dielectric material.'''


### PR DESCRIPTION
All files now use `from __future__ import absolute_import`, and the [Python 3 absolute vs relative import syntax](https://www.python.org/dev/peps/pep-0328/).

After this change, `colorpy.test.test()` shows all tests passing in both Python 2.7 and Python 3.5 on my computer.

[Copied out of https://github.com/fish2000/ColorPy/pull/2 where I got colorpy running in Python 3 back in Feb 2014, not realizing it was a third-party repository!]
